### PR TITLE
Enable language toggle in menu view

### DIFF
--- a/plataforma/application/views/menu.php
+++ b/plataforma/application/views/menu.php
@@ -103,5 +103,23 @@ defined('BASEPATH') or exit('No direct script access allowed');
         </div>
     </div>
 </body>
+
+<?php $this->load->view('footer'); ?>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const lang = typeof getLang === 'function' ? getLang() : 'en';
+        if (lang === 'en') {
+            const buttons = document.querySelectorAll('.buttons-container .button');
+            if (buttons[0]) {
+                buttons[0].textContent = 'Insert clinical case';
+            }
+            if (buttons[1]) {
+                buttons[1].textContent = 'Structured Anamnesis';
+            }
+        }
+    });
+</script>
+
 </html>
 


### PR DESCRIPTION
## Summary
- add footer and translation script to menu view to switch text based on selected language

## Testing
- `php -l plataforma/application/views/menu.php`


------
https://chatgpt.com/codex/tasks/task_e_68a3a4f5e5e8832eaf5f26eaa8835851